### PR TITLE
Revert "JSC-60962: bump Jool version to 4.1.13 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 LABEL maintainer="Zircon team <ww_zirconsquad@jamf.com>"
 
-ARG JOOL_VER=4.1.13-r0
+ARG JOOL_VER=4.1.12-r0
 
 RUN apk --no-cache add \
     jool-tools=${JOOL_VER} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ LABEL maintainer="Zircon team <ww_zirconsquad@jamf.com>"
 ARG JOOL_VER=4.1.13-r0
 
 RUN apk --no-cache add \
-    jool-tools=${JOOL_VER}
+    jool-tools=${JOOL_VER} \
+    iptables \
+    ip6tables
 
 COPY *.sh /
 RUN chmod +x /*.sh

--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,10 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-jool instance add --netfilter --pool6 ${POOL6} default
+jool instance add --iptables --pool6 ${POOL6} default
 jool global update lowest-ipv6-mtu ${LOWEST_IPV6_MTU}
 jool global update handle-rst-during-fin-rcv ${HANDLE_RST_DURING_FIN_RCV}
 jool global update drop-externally-initiated-tcp ${DROP_EXTERNALLY_INITIATED_TCP}
+
+iptables -t mangle -A PREROUTING -j JOOL
+ip6tables -t mangle -A PREROUTING -j JOOL


### PR DESCRIPTION
Revert is caused by [Jool issue](https://github.com/NICMx/Jool/issues/424)