### PR TITLE
[JSC-72156] Upgrade docker workflow actions to node24-compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,24 +20,24 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Setup Cosign
         uses: sigstore/cosign-installer@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup image metadata
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         id: build
         with:
           context: .


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from `@v3` to `@v6` (node24)
- Upgrade `docker/setup-buildx-action` from `@v2` to `@v4` (node24)
- Upgrade `docker/login-action` from `@v2` to `@v4` (node24)
- Upgrade `docker/metadata-action` from `@v4` to `@v6` (node24)
- Upgrade `docker/build-push-action` from `@v2` to `@v7` (node24)

## Compatibility
All inputs in use (`registry`, `username`, `password`, `images`, `context`, `push`, `tags`, `labels`) are unchanged across major versions. No breaking changes affect this workflow.

## Test plan
- [ ] Verify docker build and push workflow runs successfully on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)